### PR TITLE
Fix npm install error by adding package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "bot-framework",
+  "version": "1.0.0",
+  "description": "A chatbot built using Microsoft Bot Framework",
+  "main": "src/index.ts",
+  "scripts": {
+    "start": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "axios": "^0.21.1",
+    "botbuilder": "^4.11.0",
+    "restify": "^8.5.1"
+  },
+  "devDependencies": {
+    "ts-node": "^9.1.1",
+    "typescript": "^4.1.3"
+  }
+}


### PR DESCRIPTION
Fixes #3

Add `package.json` file to the root directory to resolve npm install errors.

* Add `name` field with value `bot-framework`.
* Add `version` field with value `1.0.0`.
* Add `description` field with value `A chatbot built using Microsoft Bot Framework`.
* Add `main` field with value `src/index.ts`.
* Add `scripts` field with `start` script to run `ts-node src/index.ts`.
* Add `dependencies` field with necessary dependencies: `axios`, `botbuilder`, `restify`.
* Add `devDependencies` field with necessary dev dependencies: `ts-node`, `typescript`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fischermariano/bot-framework/pull/4?shareId=f39e2432-bdb4-4570-9cda-03f2eacd3731).