### PR TITLE
Fix npm start error by updating restify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@types/restify": "^8.5.12",
     "axios": "^0.21.1",
     "botbuilder": "^4.14.0",
-    "restify": "^8.5.1"
+    "restify": "^8.6.1"
   },
   "devDependencies": {
     "ts-node": "^10.4.0",


### PR DESCRIPTION
Fixes #12

Update the `restify` dependency version in `package.json` to fix the npm start error.

* Change the `restify` version from "^8.5.1" to "^8.6.1" in the dependencies section

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fischermariano/bot-framework/pull/13?shareId=15cd4718-aca3-4a82-89cf-7b2a208b295d).